### PR TITLE
Implement -i parameter to allow specifying which interface to bind to

### DIFF
--- a/wsdd2.c
+++ b/wsdd2.c
@@ -543,6 +543,7 @@ static void help(const char *prog, int ec, const char *fmt, ...)
 		"       -W  WSDD debug mode (incremental level)\n"
 		"       -d  go daemon\n"
 		"       -h  This message\n"
+		"       -i <interface>  Specify which interface to bind to, otherwise bind to all\n"
 		"       -l  LLMNR only\n"
 		"       -t  TCP only\n"
 		"       -u  UDP only\n"
@@ -566,8 +567,9 @@ int main(int argc, char **argv)
 	int opt;
 	const char *prog = basename(*argv);
 	unsigned int ipv46 = 0, tcpudp = 0, llmnrwsdd = 0;
+	char *ifname = NULL;
 
-	while ((opt = getopt(argc, argv, "?46LWb:dhltuw")) != -1) {
+	while ((opt = getopt(argc, argv, "?46LWb:dhltuwi:")) != -1) {
 		switch (opt) {
 		case 'L':
 			debug_L++;
@@ -605,6 +607,12 @@ int main(int argc, char **argv)
 			break;
 		case 'u':
 			tcpudp	|= _UDP;
+			break;
+		case 'i':
+			if (!optarg)
+				help(prog, EXIT_FAILURE, "-i provided without interface\n");
+			else
+				ifname = strdup(optarg);
 			break;
 		default:
 			help(prog, EXIT_FAILURE, "bad option '%c'\n", opt);
@@ -682,6 +690,7 @@ again:
 					(!strncmp(ifa->ifa_name, "veth", 4)) ||
 					(!strncmp(ifa->ifa_name, "tun", 3)) ||
 					(!strncmp(ifa->ifa_name, "zt", 2)) ||
+					(ifname && strcmp(ifa->ifa_name, ifname)) ||
 					(sv->mcast_addr &&
 					!(ifa->ifa_flags & IFF_MULTICAST)))
 					continue;


### PR DESCRIPTION
By default wsdd2 binds to all available interfaces.  In a router's case
this means it would also bind to the WAN interface, which is a security
risk.  This allows to instruct wsdd2 to which specific interface to
bind to.