### PR TITLE
Fix '-b' option parsing

### DIFF
--- a/wsd.c
+++ b/wsd.c
@@ -194,6 +194,14 @@ int set_getresp(const char *str, const char **next)
 	const char *p, *val;
 	size_t keylen, vallen;
 
+	if (str == NULL) {
+	    return -1;
+	}
+
+	if (*str == '\0') {
+	    return -1;
+	}
+
 	/* Trim leading space. */
 	while (*str && isspace(*str))
 		str++;


### PR DESCRIPTION
fix null pointer and empty string handling

The previous behavor is infinite loop

examples:
"" empty string
"vendor:for,model:bar," invalid options, please note the comma at the end

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>