### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:latest AS builder
+RUN apk add --update --no-cache \
+  make \
+  gcc \
+  musl-dev \
+  linux-headers
+COPY * /root/
+RUN cd /root/ && make && find /root 
+
+FROM alpine:latest  
+WORKDIR /root/
+COPY --from=0 /root/wsdd2 /usr/sbin/
+ENTRYPOINT /usr/sbin/wsdd2 -N $HOSTNAME -G ${WORKGROUP:-WORKGROUP}


### PR DESCRIPTION
This change adds a Dockerfile which builds the binary in an Alpine linux
image and copies it into a small Alpine image.

It requires an environment variable of HOSTNAME, and takes an optional
variable of WORKGROUP (and defaults to "WORKGROUP").

This can be tested with:
```
docker build -t ${USER}/wsdd2
docker run -ti -e HOSTNAME=MYSERVER ${USER}/wsdd2
```

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>