### PR TITLE
Fix listening port when the service is known by getservbyname()

### DIFF
--- a/wsdd2.c
+++ b/wsdd2.c
@@ -293,7 +293,7 @@ static int open_ep(struct endpoint **epp, struct service *sv,
 		};
 		struct servent *se = getservbyname(sv->port_name,
 						servicename[sv->type]);
-		ep->port = se ? se->s_port : 0;
+		ep->port = se ? ntohs(se->s_port) : 0;
 		if (!ep->port)
 			ep->port = sv->port_num;
 		if (!ep->port) {


### PR DESCRIPTION
se->s_port is network byte order and needs conversion.