### PR TITLE
some small bug fixes and add the possibility to build without using t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Microsoft is moving to support mDNS/DNS-SD, but not yet there.
 
 The primary purpose of this project is to enable WSD on Samba servers so that network shares
 hosted on a Unix box can appear in Windows File Explorer / Network.
+If you predefine WITHOUT_TESTPARM as a macro when building,
+wsdd2 can be used on lightweight Samba servers without testparm support.
 
 NOTE: Make sure there is no firewall rule blocking WSD multicast address
 239.255.255.250 and ff02::c, protocol UDP port 3702. Unicast SOAP HTTP

--- a/wsd.c
+++ b/wsd.c
@@ -928,7 +928,7 @@ again:
 		if ((val = HEADER_IS(p, "Content-Type:"))) {
 			while (*val == ' ' || *val == '\t' || *val == '\r' || *val == '\n')
 				val++; // skip LWS
-			if (strcmp(val, "application/soap+xml") != 0) {
+			if (strncmp(val, "application/soap+xml", 20) != 0) {
 				ep->errstr = __FUNCTION__ ": Unsupported Content-Type";
 				return 400;
 			}

--- a/wsdd.h
+++ b/wsdd.h
@@ -27,7 +27,6 @@
 #include <net/if.h> // IFNAMSIZ
 #include <arpa/inet.h> // ntohs()
 #include <netinet/in.h> // struct sockaddr_in, struct ip_mreq
-#include <linux/in.h> // struct ip_mreqn
 #include <linux/netlink.h> // struct sockaddr_nl
 #include <time.h> // time_t, time()
 

--- a/wsdd2.8
+++ b/wsdd2.8
@@ -18,8 +18,8 @@ wsdd2 \- server to provide WSDD/LLMNR services to clients
 .SH "SYNOPSIS"
 .HP \w'\ 'u
 wsddd2 [\-h] [\-d] [\-4] [\-6] [\-u] [\-t] [\-l] [\-w] [\-L] [\-W]
-[\-i <intrerface>] [\-H <hostname>] [\-N <netbiosname>] [\-G <workgroup>]
-[\-b <kvlist>]
+[\-i <intrerface>] [\-H <hostname>] [\-A <hostaliases>] [\-N <netbiosname>] 
+[\-B <netbiosaliases>] [\-G <workgroup>] [\-b <kvlist>]
 
 .SH "DESCRIPTION"
 .PP
@@ -124,12 +124,30 @@ functions.
 .RE
 
 .PP
+\-A <hostaliases>
+.RS 4
+Use specified string as list of DNS machine names instead of value 
+returned by
+.br
+\fBtestparm -s --parameter-name="additional dns hostnames"\fR command.
+.RE
+
+.PP
 \-N <nebiosname>
 .RS 4
 Use specified string as NETBIOS machine name instead of value returned by
 .br
 \fBtestparm -s --parameter-name="netbios name"\fR command or system host
 name.
+.RE
+
+.PP
+\-B <nebiosaliases>
+.RS 4
+Use specified string as list of NETBIOS machine names instead of value 
+returned by
+.br
+\fBtestparm -s --parameter-name="netbios aliases"\fR command.
 .RE
 
 .PP


### PR DESCRIPTION
…estparm

wsd.c:
With the change Dolphin shows the hostname and not only the IP. Content-Type can additionally contain one or more parameters separated by semicolon. Dolphin also sends the charset among other things.

wsdd.h:
I had to remove the include because otherwise the following build error comes.
error: redefinition of 'struct sockaddr_in'
netinet/in.h and linux/in.h should never be used together. linux/in.h is for kernel builds and netinet/in.h is for userland builds. Also, in wsdd2.c _GNU_SOURCE is defined and thus struct ip_mreqn is available via bits/in.h.

wsdd2.c:
Here my changes should be self-explanatory.