### PR TITLE
Added config file parameter and command-line option, improved handling without testparm, relaxed Content-Type checks

### DIFF
--- a/llmnr.c
+++ b/llmnr.c
@@ -201,7 +201,7 @@ static int llmnr_send_response(struct endpoint *ep, _saddr_t *sa,
 
 	/* verify in_name_len */
 	if (in_name_len != strlen(in_name)) {
-		DEBUG(1, L, "llmnr: bad name length %ld != %ld", in_name_len, strlen(in_name));
+		DEBUG(1, L, "llmnr: bad name length %zu != %zu", in_name_len, strlen(in_name));
 		free(in_name);
 		return -1;
 	}

--- a/nl_debug.c
+++ b/nl_debug.c
@@ -1227,18 +1227,18 @@ int main(int argc, char *argv[])
     rc = connect(nls, (struct sockaddr *) &nlraddr, sizeof(nlraddr));
     if (rc != 0) goto fail;
 
-    size_t nlslen = sizeof(nlsaddr);
+    socklen_t nlslen = sizeof(nlsaddr);
     rc = getsockname(nls, (struct sockaddr *) &nlsaddr, &nlslen);
     if (rc < 0) goto fail;
 
-    outf("getsockname: len=%d family=%d pid=%d groups=%#x\n", nlslen,
+    outf("getsockname: len=%u family=%d pid=%d groups=%#x\n", (unsigned) nlslen,
         nlsaddr.nl_family, nlsaddr.nl_pid, nlsaddr.nl_groups);
 
-    size_t nlrlen = sizeof(nlraddr);
+    socklen_t nlrlen = sizeof(nlraddr);
     rc = getpeername(nls, (struct sockaddr *) &nlraddr, &nlrlen);
     if (rc < 0) goto fail;
 
-    outf("getpeername: len=%d family=%d pid=%d groups=%#x\n", nlrlen,
+    outf("getpeername: len=%u family=%d pid=%d groups=%#x\n", (unsigned) nlrlen,
         nlraddr.nl_family, nlraddr.nl_pid, nlraddr.nl_groups);
 
     //rc = fcntl(nls, F_GETFL, 0);

--- a/wsd.c
+++ b/wsd.c
@@ -472,7 +472,7 @@ static int wsd_send_msg(int fd, struct endpoint *ep, const _saddr_t *sa,
 
 	char ip[_ADDRSTRLEN];
 	inet_ntop(sa->ss.ss_family, _SIN_ADDR(sa), ip, sizeof ip);
-	DEBUG(3, W, "WSD-TO %s port %u (fd=%d,len=%ld,sent=%d) '%s'\n", ip, _SIN_PORT(sa), fd,
+	DEBUG(3, W, "WSD-TO %s port %u (fd=%d,len=%zu,sent=%d) '%s'\n", ip, _SIN_PORT(sa), fd,
 		msglen, ret, msg);
 
 	return ret != (int) msglen;
@@ -1071,7 +1071,7 @@ int wsd_recv(struct endpoint *ep)
 	{
 		char ip[_ADDRSTRLEN];
 		inet_ntop(sa.ss.ss_family, _SIN_ADDR(&sa), ip, sizeof ip);
-		DEBUG(3, W, "WSD-FROM %s port %u (fd=%d,len=%ld): '%s'\n", ip, _SIN_PORT(&sa), fd, len, buf);
+		DEBUG(3, W, "WSD-FROM %s port %u (fd=%d,len=%zd): '%s'\n", ip, _SIN_PORT(&sa), fd, len, buf);
 	}
 
 	if (ep->type == SOCK_STREAM && strncmp(buf, "POST ", 5) == 0) {
@@ -1080,7 +1080,7 @@ int wsd_recv(struct endpoint *ep)
 		{
 			char ip[_ADDRSTRLEN];
 			inet_ntop(sa.ss.ss_family, _SIN_ADDR(&sa), ip, sizeof ip);
-			DEBUG(3, W, "WSD-BODY %s port %u (fd=%d,status=%d,len=%ld): '%s'\n", ip, _SIN_PORT(&sa),
+			DEBUG(3, W, "WSD-BODY %s port %u (fd=%d,status=%d,len=%zu): '%s'\n", ip, _SIN_PORT(&sa),
 				fd, status, strlen(buf), buf);
 		}
 

--- a/wsd.c
+++ b/wsd.c
@@ -928,7 +928,8 @@ again:
 		if ((val = HEADER_IS(p, "Content-Type:"))) {
 			while (*val == ' ' || *val == '\t' || *val == '\r' || *val == '\n')
 				val++; // skip LWS
-			if (strcmp(val, "application/soap+xml") != 0) {
+			if (strncmp(val, "application/soap+xml", 20) != 0 ||
+					!(val[20] == '\0' || val[20] == ';' || val[20] == ' ' || val[20] == '\t' || val[20] == '\r' || val[20] == '\n')) {
 				ep->errstr = __FUNCTION__ ": Unsupported Content-Type";
 				return 400;
 			}

--- a/wsdd2.8
+++ b/wsdd2.8
@@ -18,8 +18,8 @@ wsdd2 \- server to provide WSDD/LLMNR services to clients
 .SH "SYNOPSIS"
 .HP \w'\ 'u
 wsddd2 [\-h] [\-d] [\-4] [\-6] [\-u] [\-t] [\-l] [\-w] [\-L] [\-W]
-[\-i <intrerface>] [\-H <hostname>] [\-N <netbiosname>] [\-G <workgroup>]
-[\-b <kvlist>]
+[\-i <intrerface>] [\-H <hostname>] [\-A <hostaliases>] [\-N <netbiosname>]
+[\-B <netbiosaliases>] [\-G <workgroup>] [\-b <kvlist>]
 
 .SH "DESCRIPTION"
 .PP
@@ -124,12 +124,30 @@ functions.
 .RE
 
 .PP
+\-A <hostaliases>
+.RS 4
+Use specified string as list of DNS machine names instead of value
+returned by
+.br
+\fBtestparm -s --parameter-name="additional dns hostnames"\fR command.
+.RE
+
+.PP
 \-N <nebiosname>
 .RS 4
 Use specified string as NETBIOS machine name instead of value returned by
 .br
 \fBtestparm -s --parameter-name="netbios name"\fR command or system host
 name.
+.RE
+
+.PP
+\-B <nebiosaliases>
+.RS 4
+Use specified string as list of NETBIOS machine names instead of value
+returned by
+.br
+\fBtestparm -s --parameter-name="netbios aliases"\fR command.
 .RE
 
 .PP

--- a/wsdd2.8
+++ b/wsdd2.8
@@ -18,8 +18,8 @@ wsdd2 \- server to provide WSDD/LLMNR services to clients
 .SH "SYNOPSIS"
 .HP \w'\ 'u
 wsddd2 [\-h] [\-d] [\-4] [\-6] [\-u] [\-t] [\-l] [\-w] [\-L] [\-W]
-[\-i <intrerface>] [\-H <hostname>] [\-A <hostaliases>] [\-N <netbiosname>]
-[\-B <netbiosaliases>] [\-G <workgroup>] [\-b <kvlist>]
+[\-i <intrerface>] [\c <file>] [\-H <hostname>] [\-A <hostaliases>]
+[\-N <netbiosname>] [\-B <netbiosaliases>] [\-G <workgroup>] [\-b <kvlist>]
 
 .SH "DESCRIPTION"
 .PP
@@ -113,6 +113,13 @@ Use only specified interface to reply to incoming requests. Specifying "any"
 or leaving option out causes \fBwsdd2\fR to listen on every IPv4 or IPv6
 capable interface excluding those that have names matching LeafNets,
 docker*, veth*, tun*, ppp*, zt*.
+.RE
+
+.PP
+\-c <file>
+.RS 4
+Read \fBsmb.conf\fR from the specified file path. If not specified,
+\fBtestparm\fR default file location will be used.
 .RE
 
 .PP

--- a/wsdd2.c
+++ b/wsdd2.c
@@ -649,6 +649,7 @@ static char *get_smbparm(bool use_testparm, const char *name, const char *_defau
 			*p = '\0';
 		for (p = buf; *p && isspace(*p); p++)
 			;
+		DEBUG(2, W, "testparm found value of \"%s\": %s", name, p);
 		result = strdup(p);
 	}
 

--- a/wsdd2.c
+++ b/wsdd2.c
@@ -693,7 +693,7 @@ int main(int argc, char **argv)
 
 	init_sysinfo();
 
-	while ((opt = getopt(argc, argv, "hd46utlwLWi:H:N:G:b:")) != -1) {
+	while ((opt = getopt(argc, argv, "hd46utlwLWi:H:A:N:B:G:b:")) != -1) {
 		switch (opt) {
 		case 'h':
 			help(prog, EXIT_SUCCESS, NULL);
@@ -740,9 +740,17 @@ int main(int argc, char **argv)
 			if (optarg != NULL && strlen(optarg) > 0)
 				hostname = strdup(optarg);
 			break;
+		case 'A':
+			if (optarg != NULL && strlen(optarg) > 0)
+				hostaliases = strdup(optarg);
+			break;
 		case 'N':
 			if (optarg != NULL && strlen(optarg) > 0)
 				netbiosname = strdup(optarg);
+			break;
+		case 'B':
+			if (optarg != NULL && strlen(optarg) > 0)
+				netbiosaliases = strdup(optarg);
 			break;
 		case 'G':
 			if (optarg != NULL && strlen(optarg) > 0)
@@ -754,7 +762,7 @@ int main(int argc, char **argv)
 					help(prog, EXIT_FAILURE, "Bad key:val '%s'", optarg);
 			break;
 		case '?':
-			if (strchr("iHNGb", optopt))
+			if (strchr("iHNAGBb", optopt))
 				printf("Option -%c requires an argument.\n", optopt);
 			/* ... fall through ... */
 		default:

--- a/wsdd2.c
+++ b/wsdd2.c
@@ -640,8 +640,11 @@ static char *get_smbparm(bool use_testparm, const char *name, const char *_defau
 	}
 
 	char buf[PAGE_SIZE];
-	if (!fgets(buf, sizeof(buf), pp) || !buf[0]  || buf[0] == '\n') {
+	if (!fgets(buf, sizeof(buf), pp) || !buf[0]) {
 		DEBUG(0, W, "cannot read %s from testparm", name);
+		result = strdup(_default);
+	} else if (buf[0] == '\n') {
+		DEBUG(1, W, "testparm have not found value of \"%s\", using default: %s", name, _default);
 		result = strdup(_default);
 	} else { // trim whitespace
 		char *p;

--- a/wsdd2.c
+++ b/wsdd2.c
@@ -671,43 +671,6 @@ static void find_config_file()
 		free(config_file);
 }
 
-static void help(const char *prog, int ec, const char *fmt, ...)
-{
-	if (fmt) {
-		va_list ap;
-		va_start(ap, fmt);
-		vprintf(fmt, ap);
-		va_end(ap);
-		puts("\n");
-	}
-	printf( "WSDD and LLMNR daemon\n"
-		"Usage: %s [options]\n"
-		"       -h this message\n"
-		"       -d become daemon\n"
-		"       -4 IPv4 only\n"
-		"       -6 IPv6 only\n"
-		"       -u UDP only\n"
-		"       -t TCP only\n"
-		"       -l LLMNR only\n"
-		"       -w WSDD only\n"
-		"       -L increment LLMNR debug level (%d)\n"
-		"       -W increment WSDD debug level (%d)\n"
-		"       -i <interface> reply only on this interface (%s)\n"
-		"       -c <file> read smb.conf from non-default location (%s)\n"
-		"       -H <name> set host name (%s)\n"
-		"       -A \"name list\" set host aliases (%s)\n"
-		"       -N <name> set netbios name (%s)\n"
-		"       -B \"name list\" set netbios aliases (%s)\n"
-		"       -G <name> set workgroup (%s)\n"
-		"       -b \"key1:val1,key2:val2,...\" boot parameters:\n",
-		prog, debug_L, debug_W, ifname ? ifname : "any",
-		smb_conf ? smb_conf : "default",
-		hostname, hostaliases, netbiosname, netbiosaliases, workgroup
-	);
-	printBootInfoKeys(stdout, 11);
-	exit(ec);
-}
-
 static void init_sysinfo()
 {
 	bool has_testparm = check_testparm();
@@ -755,6 +718,45 @@ static void init_sysinfo()
 	init_getresp();
 }
 
+static void help(const char *prog, int ec, const char *fmt, ...)
+{
+	init_sysinfo();
+
+	if (fmt) {
+		va_list ap;
+		va_start(ap, fmt);
+		vprintf(fmt, ap);
+		va_end(ap);
+		puts("\n");
+	}
+	printf( "WSDD and LLMNR daemon\n"
+			"Usage: %s [options]\n"
+			"       -h this message\n"
+			"       -d become daemon\n"
+			"       -4 IPv4 only\n"
+			"       -6 IPv6 only\n"
+			"       -u UDP only\n"
+			"       -t TCP only\n"
+			"       -l LLMNR only\n"
+			"       -w WSDD only\n"
+			"       -L increment LLMNR debug level (%d)\n"
+			"       -W increment WSDD debug level (%d)\n"
+			"       -i <interface> reply only on this interface (%s)\n"
+			"       -c <file> read smb.conf from non-default location (%s)\n"
+			"       -H <name> set host name (%s)\n"
+			"       -A \"name list\" set host aliases (%s)\n"
+			"       -N <name> set netbios name (%s)\n"
+			"       -B \"name list\" set netbios aliases (%s)\n"
+			"       -G <name> set workgroup (%s)\n"
+			"       -b \"key1:val1,key2:val2,...\" boot parameters:\n",
+			prog, debug_L, debug_W, ifname ? ifname : "any",
+			smb_conf ? smb_conf : "default",
+			hostname, hostaliases, netbiosname, netbiosaliases, workgroup
+	);
+	printBootInfoKeys(stdout, 11);
+	exit(ec);
+}
+
 #define	_4	1
 #define	_6	2
 #define _TCP	1
@@ -767,13 +769,12 @@ int main(int argc, char **argv)
 	int opt;
 	const char *prog = basename(argv[0]);
 	unsigned int ipv46 = 0, tcpudp = 0, llmnrwsdd = 0;
-
-	init_sysinfo();
+	bool print_help = false;
 
 	while ((opt = getopt(argc, argv, "hd46utlwLWi:H:A:N:B:G:b:c:")) != -1) {
 		switch (opt) {
 		case 'h':
-			help(prog, EXIT_SUCCESS, NULL);
+			print_help = true;
 			break;
 		case 'd':
 			is_daemon = true;
@@ -853,6 +854,11 @@ int main(int argc, char **argv)
 
 	if (argc > optind)
 		help(prog, EXIT_FAILURE, "Unknown argument '%s'", argv[optind]);
+
+	if (print_help)
+		help(prog, EXIT_SUCCESS, NULL);
+
+	init_sysinfo();
 
 	if (!ipv46)
 		ipv46 = _4 | _6;


### PR DESCRIPTION
This Pull Request contains multiple fixes and improvements:

* Compile-time fixes for sockelen_t usages and printf size_t/ssize_t usages
* More relaxed Content-Type value checking - allow semicolon and spaces around the expected value
* Added missing -A and -B options, which are described in the help text
* Allow usage completely without testparm, indicate this in the help output
* When printing help, first process all options and indicate actual values in the help output
* Added logging of read values from configuration

Obsoletes: #44

